### PR TITLE
Fix invalid type references on gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Gradle files
+.gradle/
+build/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+output.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,23 +14,19 @@ The REST API documentation can be found on [llama-stack](https://docs.llama-sta
 
 ## Getting started
 
-### Install dependencies
+### Build the jar packages
 
-#### Gradle
+In your terminal, under the `llama-stack-client-kotlin` directory, run the following command:
 
-```kotlin
-implementation("com.llama_stack_client.api:llama-stack-client-kotlin:0.0.1-alpha.0")
+```
+export SKIP_MOCK_TESTS=true
+./gradlew build 
 ```
 
-#### Maven
+Output: .jar files located in the build/libs directory of the respective client folders (llama-stack-client-kotlin, llama-stack-client-kotlin-client-okhttp, llama-stack-client-kotlin-core) 
 
-```xml
-<dependency>
-    <groupId>com.llama_stack_client.api</groupId>
-    <artifactId>llama-stack-client-kotlin</artifactId>
-    <version>0.0.1-alpha.0</version>
-</dependency>
-```
+
+Note: Maven dependencies are not available at the moment. We will made it available in the near future once the SDK stabilizes. For now, build the Kotlin SDK jars manually and include them in your projects.
 
 ### Configure the client
 

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama_stack_client/api/models/AgentCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama_stack_client/api/models/AgentCreateParams.kt
@@ -3834,7 +3834,7 @@ constructor(
                         @ExcludeMissing
                         fun _additionalProperties(): Map<String, JsonValue> = additionalProperties
 
-                        fun validate(): Type = apply {
+                        fun validate(): QueryGeneratorConfig.Type = apply {
                             if (!validated) {
                                 type()
                                 validated = true
@@ -3849,8 +3849,8 @@ constructor(
                             }
 
                             return other is Type &&
-                                this.type == other.type &&
-                                this.additionalProperties == other.additionalProperties
+                                this.type == other &&
+                                this.additionalProperties == this.additionalProperties
                         }
 
                         override fun hashCode(): Int {
@@ -3874,7 +3874,7 @@ constructor(
                             private var additionalProperties: MutableMap<String, JsonValue> =
                                 mutableMapOf()
 
-                            internal fun from(type: Type) = apply {
+                            internal fun from(type: QueryGeneratorConfig.Type) = apply {
                                 this.type = type.type
                                 additionalProperties(type.additionalProperties)
                             }
@@ -3900,7 +3900,8 @@ constructor(
                                 additionalProperties: Map<String, JsonValue>
                             ) = apply { this.additionalProperties.putAll(additionalProperties) }
 
-                            fun build(): Type = Type(type, additionalProperties.toUnmodifiable())
+                            fun build(): QueryGeneratorConfig.Type =
+                                Type(type, additionalProperties.toUnmodifiable())
                         }
 
                         class Type


### PR DESCRIPTION
The generated Stainless SDK has some compilation error during gradle build, making it unable to generate jars.
This PR fixes that and improved our Readme to add instructions on how to build those jars.

The SDK is not available yet in Maven, so removing that instructions for now. Instead will supplement those commands on how to manually build those jar files


```
(base) riandymdn@riandymdn-mbp llama-stack-client-kotlin % ./gradlew build            

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 8s
39 actionable tasks: 5 executed, 34 up-to-date
```