### PR TITLE
Add build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ google-services.json
 *.hprof
 
 .DS_Store
+
+build-jars/

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ The REST API documentation can be found on [llama-stack](https://docs.llama-sta
 In your terminal, under the `llama-stack-client-kotlin` directory, run the following command:
 
 ```
-export SKIP_MOCK_TESTS=true
-./gradlew build 
+sh build-libs.sh
 ```
 
-Output: .jar files located in the build/libs directory of the respective client folders (llama-stack-client-kotlin, llama-stack-client-kotlin-client-okhttp, llama-stack-client-kotlin-core) 
+Output: .jar files located in the build-jars directory
 
 
 Note: Maven dependencies are not available at the moment. We will made it available in the near future once the SDK stabilizes. For now, build the Kotlin SDK jars manually and include them in your projects.

--- a/build-libs.sh
+++ b/build-libs.sh
@@ -1,0 +1,19 @@
+# Skip Prism mock test. If you want to enable this (SKIP_MOCK_TESTS=false), you will need to setup Prism server.
+# You can follow the error instructions on how to setup and run a server prism
+export SKIP_MOCK_TESTS=true
+
+# Code linting
+./gradlew :llama-stack-client-kotlin-core:spotlessApply
+./gradlew :llama-stack-client-kotlin-client-okhttp:spotlessApply
+./gradlew :llama-stack-client-kotlin:spotlessApply
+
+./gradlew build 
+
+# Copy jars
+mkdir -p build-jars
+BUILD_JARS_DIR=$(pwd)/build-jars
+export BUILD_JARS_DIR
+echo $BUILD_JARS_DIR
+cp -a llama-stack-client-kotlin/build/libs/. $BUILD_JARS_DIR
+cp -a llama-stack-client-kotlin-client-okhttp/build/libs/. $BUILD_JARS_DIR
+cp -a llama-stack-client-kotlin-core/build/libs/. $BUILD_JARS_DIR


### PR DESCRIPTION
Add build scripts to gradle build the jars, and copy them into build-jars folder. This will simplify iteration and building the jars, instead of previous multi-step approach