### PR TITLE
remove folders

### DIFF
--- a/examples/.keep
+++ b/examples/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store example files demonstrating usage of this SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/llama-stack-client-kotlin-lib/.keep
+++ b/llama-stack-client-kotlin-lib/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.

--- a/llama-stack-kotlin-lib/.keep
+++ b/llama-stack-kotlin-lib/.keep
@@ -1,4 +1,0 @@
-File generated from our OpenAPI spec by Stainless.
-
-This directory can be used to store custom files to expand the SDK.
-It is ignored by Stainless code generation and its content (other than this keep file) won't be touched.


### PR DESCRIPTION
Those folders are because of old renames, examples folder won't be used, because we will have a separate dedicated demo all under llama-stack-apps repo to showcase Android flow