### PR TITLE
Local custom tool-calling support

### DIFF
--- a/build-libs.sh
+++ b/build-libs.sh
@@ -2,17 +2,14 @@
 # You can follow the error instructions on how to setup and run a server prism
 export SKIP_MOCK_TESTS=true
 
+# Clean build to remove previous jar and any artifacts
+./gradlew clean
+
 # Code linting
 ./gradlew :llama-stack-client-kotlin-core:spotlessApply
 ./gradlew :llama-stack-client-kotlin-client-okhttp:spotlessApply
 ./gradlew :llama-stack-client-kotlin:spotlessApply
 ./gradlew :llama-stack-client-kotlin-client-local:spotlessApply
-
-# Remove old jars
-rm -rf llama-stack-client-kotlin/build/libs
-rm -rf llama-stack-client-kotlin-client-okhttp/build/libs
-rm -rf llama-stack-client-kotlin-core/build/libs
-rm -rf llama-stack-client-kotlin-client-local/build/libs
 
 ./gradlew build
 

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/InferenceServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/InferenceServiceLocalImpl.kt
@@ -3,10 +3,9 @@
 package com.llama.llamastack.client.local
 
 import com.llama.llamastack.client.local.util.PromptFormatLocal
-import com.llama.llamastack.core.JsonValue
+import com.llama.llamastack.client.local.util.buildInferenceChatCompletionResponse
 import com.llama.llamastack.core.RequestOptions
 import com.llama.llamastack.core.http.StreamResponse
-import com.llama.llamastack.models.CompletionMessage
 import com.llama.llamastack.models.EmbeddingsResponse
 import com.llama.llamastack.models.InferenceChatCompletionParams
 import com.llama.llamastack.models.InferenceChatCompletionResponse
@@ -80,16 +79,7 @@ constructor(
         onResultComplete = false
         onStatsComplete = false
 
-        return InferenceChatCompletionResponse.ofChatCompletionResponse(
-            InferenceChatCompletionResponse.ChatCompletionResponse.builder()
-                .completionMessage(
-                    CompletionMessage.builder()
-                        .content(CompletionMessage.Content.ofString(resultMessage))
-                        .build()
-                )
-                .putAdditionalProperty("tps", JsonValue.from(statsMetric))
-                .build()
-        )
+        return buildInferenceChatCompletionResponse(resultMessage, statsMetric)
     }
 
     override fun chatCompletionStreaming(

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/ResponseUtil.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/ResponseUtil.kt
@@ -1,0 +1,61 @@
+package com.llama.llamastack.client.local.util
+
+import com.llama.llamastack.core.JsonValue
+import com.llama.llamastack.models.CompletionMessage
+import com.llama.llamastack.models.InferenceChatCompletionResponse
+import com.llama.llamastack.models.ToolCall
+import java.util.UUID
+
+fun buildInferenceChatCompletionResponse(
+    response: String,
+    stats: Float
+): InferenceChatCompletionResponse {
+    // check for prefix [ and suffix ] if so then tool call.
+    // parse for "toolName", "additionalProperties"
+
+    var completionMessage =
+        if (response.startsWith("[") && response.endsWith("]")) {
+            // custom tool call
+            CompletionMessage.builder()
+                .toolCalls(listOf(createCustomToolCall(response)))
+                .content(CompletionMessage.Content.ofString(""))
+                .build()
+        } else {
+            CompletionMessage.builder()
+                .content(CompletionMessage.Content.ofString(response))
+                .build()
+        }
+
+    var inferenceChatCompletionResponse =
+        InferenceChatCompletionResponse.ofChatCompletionResponse(
+            InferenceChatCompletionResponse.ChatCompletionResponse.builder()
+                .completionMessage(completionMessage)
+                .putAdditionalProperty("tps", JsonValue.from(stats))
+                .build()
+        )
+    return inferenceChatCompletionResponse
+}
+
+fun createCustomToolCall(response: String): ToolCall {
+    val startIndex = response.indexOf('(')
+    val endIndex = response.indexOf(')')
+    val toolName = response.substring(1, startIndex)
+    val paramsString = response.substring(startIndex + 1, endIndex)
+
+    val paramsJson = mutableMapOf<String, JsonValue>()
+    val paramsList = paramsString.split(", ")
+    for (param in paramsList) {
+        val keyValue = param.split("=")
+        if (keyValue.size == 2) {
+            val key = keyValue[0].trim()
+            val value = keyValue[1].trim().replace("'", "").replace("\"", "")
+            paramsJson[key] = JsonValue.from(value)
+        }
+    }
+
+    return ToolCall.builder()
+        .toolName(ToolCall.ToolName.of(toolName))
+        .arguments(ToolCall.Arguments.builder().additionalProperties(paramsJson).build())
+        .callId(UUID.randomUUID().toString())
+        .build()
+}


### PR DESCRIPTION
Enabled support for local custom tool-calling by:
- Realizing that for remote the response from the model is something like: `[createCalendarEvent(title='Dental Appointment', description='Follow up for dental appointment', startDate='2024-12-10', endDate='2024-12-10', startTime='17:00', endTime='17:00')]"`
 - Based on this, parsing the toolName (createCalendarEvent) and the remaining arguments and constructing a `ToolCall` that is passed into the `CompletionMessage`
 - Separating the `inferenceChatCompletionResponse` creation into a separate`ResponseUtil.kt` file.

Test:
https://github.com/user-attachments/assets/d6b2fc51-8cd9-47f1-84e1-2fe0d3b57f71

