### PR TITLE
Fix toolcalling timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Features:
 - Remote Inferencing: Perform inferencing tasks remotely with Llama models hosted on a remote connection (or serverless localhost).
 - Simple Integration: With easy-to-use APIs, a developer can quickly integrate Llama Stack in their Android app. The difference with local vs remote inferencing is also minimal.
 
-Latest Release Notes: [v0.1.4](https://github.com/meta-llama/llama-stack-client-kotlin/releases/tag/v0.1.4) 
+Latest Release Notes: [v0.1.4.1](https://github.com/meta-llama/llama-stack-client-kotlin/releases/tag/v0.1.4.1) 
+
+Note: The current recommended version is 0.1.4 Llama Stack server with 0.1.4.1 Kotlin client SDK. Kotlin SDK 0.1.4 has a known bug on tool calling, which will be fixed in upcoming Llama Stack server release.
 
 *Tagged releases are stable versions of the project. While we strive to maintain a stable main branch, it's not guaranteed to be free of bugs or issues.*
 
@@ -24,7 +26,7 @@ The key files in the app are `ExampleLlamaStackLocalInference.kt`, `ExampleLlama
 Add the following dependency in your `build.gradle.kts` file:
 ```
 dependencies {
- implementation("com.llama.llamastack:llama-stack-client-kotlin:0.1.4")
+ implementation("com.llama.llamastack:llama-stack-client-kotlin:0.1.4.1")
 }
 ```
 This will download jar files in your gradle cache in a directory like `~/.gradle/caches/modules-2/files-2.1/com.llama.llamastack/` 
@@ -60,7 +62,7 @@ Start a Llama Stack server on localhost. Here is an example of how you can do th
 ```
 conda create -n stack-fireworks python=3.10 
 conda activate stack-fireworks
-pip install llama-stack=0.1.4
+pip install llama-stack=0.1.4.1
 llama stack build --template fireworks --image-type conda
 export FIREWORKS_API_KEY=<SOME_KEY>
 llama stack run /Users/<your_username>/.llama/distributions/llamastack-fireworks/fireworks-run.yaml --port=5050
@@ -99,7 +101,7 @@ client = LlamaStackClientLocalClient
 client = LlamaStackClientOkHttpClient
                 .builder()
                 .baseUrl(remoteURL)
-                .headers(mapOf("x-llamastack-client-version" to listOf("0.1.4")))
+                .headers(mapOf("x-llamastack-client-version" to listOf("0.1.4.1")))
                 .build()
 ```
 </td>
@@ -286,7 +288,7 @@ The purpose of this section is to share more details with users that would like 
 ### Prerequisite
 
 You must complete the following steps:
-1. Clone the repo (`git clone https://github.com/meta-llama/llama-stack-client-kotlin.git -b release/0.1.4`)
+1. Clone the repo (`git clone https://github.com/meta-llama/llama-stack-client-kotlin.git -b release/0.1.4.1`)
 2. Port the appropriate ExecuTorch libraries over into your Llama Stack Kotlin library environment.
 ```
 cd llama-stack-client-kotlin-client-local

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 allprojects {
     group = "com.llama.llamastack"
-    version = "0.1.4"
+    version = "0.1.4.1"
 }

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceStep.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceStep.kt
@@ -50,9 +50,9 @@ private constructor(
 
     fun turnId(): String = turnId.getRequired("turn_id")
 
-    fun completedAt(): OffsetDateTime? = completedAt.getNullable("completed_at")
+    fun completedAt(): OffsetDateTime? = null
 
-    fun startedAt(): OffsetDateTime? = startedAt.getNullable("started_at")
+    fun startedAt(): OffsetDateTime? = null
 
     /** A message containing the model's (assistant) response in a chat conversation. */
     @JsonProperty("model_response")

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceStepTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceStepTest.kt
@@ -56,9 +56,9 @@ class InferenceStepTest {
             )
         assertThat(inferenceStep.stepId()).isEqualTo("step_id")
         assertThat(inferenceStep.turnId()).isEqualTo("turn_id")
-        assertThat(inferenceStep.completedAt())
-            .isEqualTo(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
-        assertThat(inferenceStep.startedAt())
-            .isEqualTo(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+        //        assertThat(inferenceStep.completedAt())
+        //            .isEqualTo(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
+        //        assertThat(inferenceStep.startedAt())
+        //            .isEqualTo(OffsetDateTime.parse("2019-12-27T18:11:19.117Z"))
     }
 }


### PR DESCRIPTION
- 0.1.4 server started returning completed_at and started_at timestamp, but it's not compliant with the OffsetDateTime format that SDK expects. This is causing the agentTurnResponseStepComplete to be missing/incorrectly type-casted to unknown. This patch will ignore the timestamp for now, at least until 0.1.5 release next week when the format is corrected on server side.