### PR TITLE
Add MIT License section to README and copyright headers to all source…

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,3 +563,7 @@ We'd like to extend our thanks to the ExecuTorch team for providing their suppor
 ---
 
 The API interface is generated using the OpenAPI standard with [Stainless](https://www.stainlessapi.com/).
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/build-libs.sh
+++ b/build-libs.sh
@@ -1,3 +1,10 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
 # Skip Prism mock test. If you want to enable this (SKIP_MOCK_TESTS=false), you will need to setup Prism server.
 # You can follow the error instructions on how to setup and run a server prism
 export SKIP_MOCK_TESTS=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
 //    id("org.jetbrains.dokka") version "2.0.0"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
     `kotlin-dsl`
     kotlin("jvm") version "1.9.22"

--- a/buildSrc/src/main/kotlin/llama-stack-client.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/llama-stack-client.java.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import com.vanniktech.maven.publish.JavaLibrary

--- a/buildSrc/src/main/kotlin/llama-stack-client.kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/llama-stack-client.kotlin.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile

--- a/buildSrc/src/main/kotlin/llama-stack-client.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/llama-stack-client.publish.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure

--- a/llama-stack-client-kotlin-client-local/build.gradle.kts
+++ b/llama-stack-client-kotlin-client-local/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
     id("llama-stack-client.kotlin")
     id("llama-stack-client.publish")

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LlamaStackClientClientLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LlamaStackClientClientLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client.local

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LlamaStackClientLocalClient.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LlamaStackClientLocalClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local
 
 import com.llama.llamastack.client.LlamaStackClientClient

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LocalClientOptions.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/LocalClientOptions.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client.local

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/AgentServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/AgentServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/InferenceServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/InferenceServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client.local.services

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/ToolRuntimeServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/ToolRuntimeServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/VectorDbServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/VectorDbServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/VectorIoServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/VectorIoServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/agents/SessionServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/agents/SessionServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services.agents
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/agents/TurnServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/agents/TurnServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services.agents
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/toolruntime/RagToolServiceLocalImpl.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/toolruntime/RagToolServiceLocalImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services.toolruntime
 
 import com.llama.llamastack.client.local.LocalClientOptions

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/vectordb/objectbox/RagVectorDb.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/services/vectordb/objectbox/RagVectorDb.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.services.vectordb.objectbox
 
 import io.objectbox.annotation.Entity

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/PromptFormatLocal.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/PromptFormatLocal.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.util
 
 import com.llama.llamastack.models.AgentTurnCreateParams

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/RagVectorDbUtil.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/RagVectorDbUtil.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.util
 
 import com.llama.llamastack.client.local.services.vectordb.objectbox.RagVectorDb

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/ResponseUtil.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/ResponseUtil.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.util
 
 import com.llama.llamastack.core.JsonValue

--- a/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/SharedUtils.kt
+++ b/llama-stack-client-kotlin-client-local/src/main/kotlin/com/llama/llamastack/client/local/util/SharedUtils.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.local.util
 
 import com.llama.llamastack.errors.LlamaStackClientException

--- a/llama-stack-client-kotlin-client-okhttp/build.gradle.kts
+++ b/llama-stack-client-kotlin-client-okhttp/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
     id("llama-stack-client.kotlin")
     id("llama-stack-client.publish")

--- a/llama-stack-client-kotlin-core/build.gradle.kts
+++ b/llama-stack-client-kotlin-core/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
     id("llama-stack-client.kotlin")
     id("llama-stack-client.publish")

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClient.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/client/LlamaStackClientClientImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/BaseDeserializer.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/BaseDeserializer.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.fasterxml.jackson.core.JsonParser

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/BaseSerializer.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/BaseSerializer.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.fasterxml.jackson.databind.ser.std.StdSerializer

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Check.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Check.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.fasterxml.jackson.core.Version

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/ClientOptions.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/ClientOptions.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/ObjectMappers.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/ObjectMappers.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("ObjectMappers")
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Params.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Params.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.llama.llamastack.core.http.Headers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/PhantomReachable.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/PhantomReachable.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("PhantomReachable")
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/PrepareRequest.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/PrepareRequest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.llama.llamastack.core.http.HttpRequest

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Properties.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Properties.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("Properties")
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/RequestOptions.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/RequestOptions.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import java.time.Duration

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Timeout.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Timeout.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Utils.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Utils.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("Utils")
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Values.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/Values.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationsInside

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/EmptyHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/EmptyHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("EmptyHandler")
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/ErrorHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/ErrorHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/JsonHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/JsonHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("JsonHandler")
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/SseHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/SseHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/StreamHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/StreamHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("StreamHandler")
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/StringHandler.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/handlers/StringHandler.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 @file:JvmName("StringHandler")
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/Headers.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/Headers.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.toImmutable

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpClient.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.RequestOptions

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpMethod.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpMethod.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 enum class HttpMethod {

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequest.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.checkRequired

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequestBodies.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequestBodies.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.http

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequestBody.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpRequestBody.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import java.io.OutputStream

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.http

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpResponseFor.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/HttpResponseFor.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import java.io.InputStream

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/PhantomReachableClosingHttpClient.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/PhantomReachableClosingHttpClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.RequestOptions

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/PhantomReachableClosingStreamResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/PhantomReachableClosingStreamResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.closeWhenPhantomReachable

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/QueryParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/QueryParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.http

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/RetryingHttpClient.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/RetryingHttpClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.llama.llamastack.core.RequestOptions

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/SseMessage.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/SseMessage.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.http

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/StreamResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/core/http/StreamResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 interface StreamResponse<T> : AutoCloseable {

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/BadRequestException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/BadRequestException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/InternalServerException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/InternalServerException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.errors
 
 open class LlamaStackClientException(message: String? = null, cause: Throwable? = null) :

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientInvalidDataException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientInvalidDataException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.errors
 
 class LlamaStackClientInvalidDataException(message: String? = null, cause: Throwable? = null) :

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientIoException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientIoException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.errors
 
 class LlamaStackClientIoException(message: String? = null, cause: Throwable? = null) :

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientServiceException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/LlamaStackClientServiceException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/NotFoundException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/NotFoundException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/PermissionDeniedException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/PermissionDeniedException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/RateLimitException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/RateLimitException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/SseException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/SseException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnauthorizedException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnauthorizedException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnexpectedStatusCodeException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnexpectedStatusCodeException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnprocessableEntityException.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/errors/UnprocessableEntityException.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.errors

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentConfig.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentConfig.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentCreateResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentCreateResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentDeleteParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentDeleteParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionCreateResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionCreateResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionDeleteParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionDeleteParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentSessionRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentStepRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentStepRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentStepRetrieveResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentStepRetrieveResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnResponseStreamChunk.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnResponseStreamChunk.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnResumeParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnResumeParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AgentTurnRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AlgorithmConfig.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/AlgorithmConfig.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BatchCompletion.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BatchCompletion.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Benchmark.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Benchmark.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkConfig.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkConfig.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/BenchmarkRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionChunk.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionChunk.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionCreateResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionCreateResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionListResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionListResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionResponseStreamChunk.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionResponseStreamChunk.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionCreateResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionCreateResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionMessage.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionMessage.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CompletionResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ContentDelta.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ContentDelta.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CreateEmbeddingsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/CreateEmbeddingsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DataEnvelope.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DataEnvelope.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetIterrowsParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetIterrowsParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetIterrowsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetIterrowsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRegisterResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRegisterResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRetrieveResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetRetrieveResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetUnregisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DatasetUnregisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DeleteFileResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/DeleteFileResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Document.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Document.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EmbeddingCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EmbeddingCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EmbeddingsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EmbeddingsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalCandidate.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalCandidate.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalEvaluateRowsAlphaParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalEvaluateRowsAlphaParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalEvaluateRowsParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalEvaluateRowsParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobCancelParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobCancelParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobStatusParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalJobStatusParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalRunEvalAlphaParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalRunEvalAlphaParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalRunEvalParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvalRunEvalParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvaluateResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/EvaluateResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Event.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Event.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/File.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/File.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileContentParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileContentParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileContentResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileContentResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileDeleteParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileDeleteParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/FileRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/HealthInfo.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/HealthInfo.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchCompletionParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceBatchCompletionParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceChatCompletionParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceChatCompletionParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceCompletionParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceCompletionParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceEmbeddingsParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceEmbeddingsParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceStep.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InferenceStep.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InspectHealthParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InspectHealthParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InspectVersionParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InspectVersionParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InterleavedContent.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InterleavedContent.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InterleavedContentItem.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/InterleavedContentItem.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Job.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Job.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListBenchmarksResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListBenchmarksResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListDatasetsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListDatasetsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListFilesResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListFilesResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListModelsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListModelsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListPostTrainingJobsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListPostTrainingJobsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListProvidersResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListProvidersResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListRoutesResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListRoutesResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListScoringFunctionsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListScoringFunctionsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListShieldsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListShieldsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListToolGroupsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListToolGroupsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListToolsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListToolsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListVectorDbsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListVectorDbsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListVectorStoresResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ListVectorStoresResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/MemoryRetrievalStep.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/MemoryRetrievalStep.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Message.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Message.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Model.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Model.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelUnregisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ModelUnregisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ParamType.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ParamType.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJob.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJob.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobCancelParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobCancelParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobStatusParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobStatusParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobStatusResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingJobStatusResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingPreferenceOptimizeParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingPreferenceOptimizeParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingSupervisedFineTuneParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/PostTrainingSupervisedFineTuneParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderInfo.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderInfo.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ProviderRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryChunksResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryChunksResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryCondition.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryCondition.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryConfig.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryConfig.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryGeneratorConfig.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryGeneratorConfig.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryResult.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QueryResult.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QuerySpansResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/QuerySpansResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseFormat.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseFormat.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseInputItemListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseInputItemListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseInputItemListResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseInputItemListResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseListResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseListResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseObject.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseObject.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseObjectStream.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseObjectStream.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ResponseRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ReturnType.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ReturnType.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RouteInfo.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RouteInfo.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RouteListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RouteListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RunShieldResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/RunShieldResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SafetyRunShieldParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SafetyRunShieldParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SafetyViolation.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SafetyViolation.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SamplingParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SamplingParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFn.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFn.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFnParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFnParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringFunctionRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringResult.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringResult.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreBatchParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreBatchParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreBatchResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreBatchResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ScoringScoreResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Session.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Session.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Shield.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Shield.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldCallStep.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldCallStep.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ShieldRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SpanWithStatus.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SpanWithStatus.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SyntheticDataGenerationGenerateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SyntheticDataGenerationGenerateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SyntheticDataGenerationResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SyntheticDataGenerationResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SystemMessage.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/SystemMessage.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetTraceParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryGetTraceParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryLogEventParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryLogEventParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryQuerySpansParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryQuerySpansParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryQueryTracesParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetryQueryTracesParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetrySaveSpansToDatasetParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TelemetrySaveSpansToDatasetParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TokenLogProbs.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TokenLogProbs.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Tool.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Tool.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolCall.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolCall.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolCallOrString.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolCallOrString.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolDef.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolDef.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolExecutionStep.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolExecutionStep.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolGetParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolGetParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolGroup.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolGroup.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolInvocationResult.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolInvocationResult.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolParamDefinition.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolParamDefinition.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolResponseMessage.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolResponseMessage.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeInvokeToolParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeInvokeToolParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeListToolsParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeListToolsParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolInsertParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolInsertParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolQueryParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolQueryParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupGetParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupGetParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupUnregisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/ToolgroupUnregisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Trace.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Trace.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Turn.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/Turn.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TurnResponseEvent.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TurnResponseEvent.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TurnResponseEventPayload.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/TurnResponseEventPayload.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/UserMessage.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/UserMessage.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRegisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRegisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRegisterResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRegisterResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRetrieveResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbRetrieveResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbUnregisterParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorDbUnregisterParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorIoInsertParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorIoInsertParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorIoQueryParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorIoQueryParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStore.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStore.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreDeleteParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreDeleteParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreDeleteResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreDeleteResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreFile.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreFile.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreFileCreateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreFileCreateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreListParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreListParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreRetrieveParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreRetrieveParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreSearchParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreSearchParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreSearchResponse.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreSearchResponse.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreUpdateParams.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VectorStoreUpdateParams.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VersionInfo.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/models/VersionInfo.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/AgentServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/AgentServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/AgentServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/AgentServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ChatServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ChatServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ChatServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ChatServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/CompletionServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/CompletionServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/CompletionServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/CompletionServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/DatasetServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/DatasetServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/DatasetServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/DatasetServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EvalServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EvalServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EvalServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/EvalServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/FileServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/FileServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/FileServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/FileServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InferenceServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InferenceServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InferenceServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InferenceServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InspectServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InspectServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InspectServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/InspectServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ModelServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ModelServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ModelServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ModelServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ProviderServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ProviderServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ProviderServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ProviderServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ResponseServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ResponseServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ResponseServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ResponseServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/RouteServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/RouteServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/RouteServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/RouteServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SafetyServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SafetyServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SafetyServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SafetyServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ScoringServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ShieldServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ShieldServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ShieldServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ShieldServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.chat

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.chat

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.eval

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.eval

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.postTraining

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.postTraining

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.responses

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.responses

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.toolRuntime

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.toolRuntime

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsync.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.vectorStores

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsyncImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsyncImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.vectorStores

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/AgentService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/AgentService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/AgentServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/AgentServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/BenchmarkService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/BenchmarkService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/BenchmarkServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/BenchmarkServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ChatService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ChatService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ChatServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ChatServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/CompletionService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/CompletionService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/CompletionServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/CompletionServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/DatasetService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/DatasetService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/DatasetServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/DatasetServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EmbeddingService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EmbeddingService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EmbeddingServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EmbeddingServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EvalService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EvalService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EvalServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/EvalServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/FileService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/FileService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/FileServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/FileServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InferenceService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InferenceService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InferenceServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InferenceServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InspectService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InspectService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InspectServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/InspectServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ModelService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ModelService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ModelServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ModelServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/PostTrainingService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/PostTrainingService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/PostTrainingServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/PostTrainingServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ProviderService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ProviderService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ProviderServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ProviderServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ResponseService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ResponseService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ResponseServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ResponseServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/RouteService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/RouteService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/RouteServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/RouteServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SafetyService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SafetyService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SafetyServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SafetyServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ScoringServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ShieldService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ShieldService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ShieldServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ShieldServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/TelemetryService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/TelemetryService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/TelemetryServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/TelemetryServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolgroupService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolgroupService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolgroupServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/ToolgroupServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorDbService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorDbService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorDbServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorDbServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorIoService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorIoService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorIoServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorIoServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorStoreService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorStoreService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorStoreServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/VectorStoreServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/SessionService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/SessionService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/SessionServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/SessionServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/StepService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/StepService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/StepServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/StepServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/TurnService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/TurnService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/TurnServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/agents/TurnServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/chat/CompletionService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/chat/CompletionService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.chat

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/chat/CompletionServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/chat/CompletionServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.chat

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/eval/JobService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/eval/JobService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.eval

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/eval/JobServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/eval/JobServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.eval

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/postTraining/JobService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/postTraining/JobService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.postTraining

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/postTraining/JobServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/postTraining/JobServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.postTraining

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/responses/InputItemService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/responses/InputItemService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.responses

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/responses/InputItemServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/responses/InputItemServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.responses

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.toolRuntime

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.toolRuntime

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileService.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileService.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.vectorStores

--- a/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileServiceImpl.kt
+++ b/llama-stack-client-kotlin-core/src/main/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileServiceImpl.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.vectorStores

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/TestServerExtension.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/TestServerExtension.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack
 
 import java.lang.RuntimeException

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ClientOptionsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ClientOptionsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ObjectMappersTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ObjectMappersTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/PhantomReachableTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/PhantomReachableTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import org.assertj.core.api.Assertions.assertThat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/UtilsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/UtilsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import org.assertj.core.api.Assertions.assertThat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ValuesTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/ValuesTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core
 
 import org.assertj.core.api.Assertions.assertThat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/handlers/SseHandlerTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/handlers/SseHandlerTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.core.handlers

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/handlers/StreamHandlerTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/handlers/StreamHandlerTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.handlers
 
 import com.llama.llamastack.core.http.Headers

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/HeadersTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/HeadersTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import org.assertj.core.api.Assertions.assertThat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/QueryParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/QueryParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import org.assertj.core.api.Assertions.assertThat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/RetryingHttpClientTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/core/http/RetryingHttpClientTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.core.http
 
 import com.github.tomakehurst.wiremock.client.WireMock.*

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentConfigTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentConfigTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentCreateResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentCreateResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentDeleteParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentDeleteParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionCreateResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionCreateResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionDeleteParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionDeleteParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentSessionRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentStepRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentStepRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentStepRetrieveResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentStepRetrieveResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnResponseStreamChunkTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnResponseStreamChunkTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnResumeParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnResumeParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AgentTurnRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AlgorithmConfigTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/AlgorithmConfigTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BatchCompletionTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BatchCompletionTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkConfigTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkConfigTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/BenchmarkTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionChunkTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionChunkTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionCreateResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionCreateResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionListResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionListResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionResponseStreamChunkTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionResponseStreamChunkTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ChatCompletionRetrieveResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionCreateResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionCreateResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionMessageTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionMessageTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CompletionResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ContentDeltaTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ContentDeltaTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CreateEmbeddingsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/CreateEmbeddingsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetIterrowsParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetIterrowsParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetIterrowsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetIterrowsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRegisterResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRegisterResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRetrieveResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetRetrieveResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetUnregisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DatasetUnregisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DeleteFileResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DeleteFileResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DocumentTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/DocumentTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EmbeddingCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EmbeddingCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EmbeddingsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EmbeddingsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalCandidateTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalCandidateTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalEvaluateRowsAlphaParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalEvaluateRowsAlphaParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalEvaluateRowsParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalEvaluateRowsParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobCancelParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobCancelParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobStatusParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalJobStatusParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalRunEvalAlphaParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalRunEvalAlphaParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalRunEvalParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvalRunEvalParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvaluateResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EvaluateResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EventTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/EventTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileContentParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileContentParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileContentResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileContentResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileDeleteParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileDeleteParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/FileTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/HealthInfoTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/HealthInfoTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchChatCompletionResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchCompletionParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceBatchCompletionParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceChatCompletionParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceChatCompletionParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceCompletionParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceCompletionParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceEmbeddingsParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceEmbeddingsParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceStepTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InferenceStepTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InspectHealthParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InspectHealthParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InspectVersionParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InspectVersionParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InterleavedContentItemTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InterleavedContentItemTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InterleavedContentTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/InterleavedContentTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/JobTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/JobTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListBenchmarksResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListBenchmarksResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListDatasetsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListDatasetsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListFilesResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListFilesResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListModelsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListModelsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListPostTrainingJobsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListPostTrainingJobsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListProvidersResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListProvidersResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListRoutesResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListRoutesResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListScoringFunctionsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListScoringFunctionsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListShieldsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListShieldsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListToolGroupsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListToolGroupsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListToolsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListToolsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListVectorDbsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListVectorDbsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListVectorStoresResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ListVectorStoresResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/MemoryRetrievalStepTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/MemoryRetrievalStepTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/MessageTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/MessageTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelUnregisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ModelUnregisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ParamTypeTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ParamTypeTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobArtifactsResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobCancelParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobCancelParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobStatusParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobStatusParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobStatusResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobStatusResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingJobTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingPreferenceOptimizeParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingPreferenceOptimizeParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingSupervisedFineTuneParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/PostTrainingSupervisedFineTuneParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderInfoTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderInfoTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ProviderRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryChunksResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryChunksResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryConditionTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryConditionTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryConfigTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryConfigTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryGeneratorConfigTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryGeneratorConfigTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryResultTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QueryResultTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QuerySpansResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/QuerySpansResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseFormatTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseFormatTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseInputItemListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseInputItemListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseInputItemListResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseInputItemListResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseListResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseListResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseObjectStreamTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseObjectStreamTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseObjectTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseObjectTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ResponseRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ReturnTypeTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ReturnTypeTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RouteInfoTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RouteInfoTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RouteListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RouteListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RunShieldResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/RunShieldResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SafetyRunShieldParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SafetyRunShieldParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SafetyViolationTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SafetyViolationTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SamplingParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SamplingParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFnParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFnParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFnTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFnTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringFunctionRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringResultTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringResultTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreBatchParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreBatchParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreBatchResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreBatchResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ScoringScoreResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SessionTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SessionTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldCallStepTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldCallStepTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ShieldTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SpanWithStatusTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SpanWithStatusTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SyntheticDataGenerationGenerateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SyntheticDataGenerationGenerateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SyntheticDataGenerationResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SyntheticDataGenerationResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SystemMessageTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/SystemMessageTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetSpanTreeResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetTraceParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryGetTraceParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryLogEventParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryLogEventParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryQuerySpansParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryQuerySpansParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryQueryTracesParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetryQueryTracesParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetrySaveSpansToDatasetParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TelemetrySaveSpansToDatasetParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TokenLogProbsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TokenLogProbsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolCallOrStringTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolCallOrStringTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolCallTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolCallTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolDefTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolDefTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolExecutionStepTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolExecutionStepTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolGetParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolGetParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolGroupTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolGroupTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolInvocationResultTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolInvocationResultTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolParamDefinitionTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolParamDefinitionTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolResponseMessageTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolResponseMessageTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeInvokeToolParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeInvokeToolParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeListToolsParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeListToolsParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolInsertParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolInsertParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolQueryParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolRuntimeRagToolQueryParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupGetParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupGetParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupUnregisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/ToolgroupUnregisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TraceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TraceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnResponseEventPayloadTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnResponseEventPayloadTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnResponseEventTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnResponseEventTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/TurnTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/UserMessageTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/UserMessageTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRegisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRegisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRegisterResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRegisterResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRetrieveResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbRetrieveResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbUnregisterParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorDbUnregisterParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorIoInsertParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorIoInsertParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorIoQueryParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorIoQueryParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreDeleteParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreDeleteParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreDeleteResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreDeleteResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreFileCreateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreFileCreateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreFileTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreFileTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreListParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreListParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreRetrieveParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreRetrieveParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreSearchParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreSearchParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreSearchResponseTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreSearchResponseTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreUpdateParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VectorStoreUpdateParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VersionInfoTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/models/VersionInfoTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.models

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/ErrorHandlingTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/ErrorHandlingTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/ServiceParamsTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/ServiceParamsTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/AgentServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/AgentServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/BenchmarkServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/CompletionServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/CompletionServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/DatasetServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/DatasetServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/EmbeddingServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/EvalServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/EvalServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/FileServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/FileServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/InferenceServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/InferenceServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/InspectServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/InspectServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ModelServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ModelServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/PostTrainingServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ProviderServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ProviderServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ResponseServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ResponseServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/RouteServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/RouteServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/SafetyServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/SafetyServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ScoringFunctionServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ScoringServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ScoringServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ShieldServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ShieldServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/SyntheticDataGenerationServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/TelemetryServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolRuntimeServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/ToolgroupServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorDbServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorIoServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/VectorStoreServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/SessionServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/StepServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/agents/TurnServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/chat/CompletionServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.chat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/eval/JobServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.eval

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/postTraining/JobServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.postTraining

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/responses/InputItemServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.responses

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/toolRuntime/RagToolServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.toolRuntime

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsyncTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/async/vectorStores/FileServiceAsyncTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.async.vectorStores

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/AgentServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/AgentServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/BenchmarkServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/BenchmarkServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/CompletionServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/CompletionServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/DatasetServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/DatasetServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/EmbeddingServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/EmbeddingServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/EvalServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/EvalServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/FileServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/FileServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/InferenceServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/InferenceServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/InspectServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/InspectServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ModelServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ModelServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/PostTrainingServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/PostTrainingServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ProviderServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ProviderServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ResponseServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ResponseServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/RouteServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/RouteServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/SafetyServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/SafetyServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ScoringFunctionServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ScoringServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ScoringServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ShieldServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ShieldServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/SyntheticDataGenerationServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/TelemetryServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/TelemetryServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolRuntimeServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolgroupServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/ToolgroupServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorDbServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorDbServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorIoServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorIoServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorStoreServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/VectorStoreServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/SessionServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/SessionServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/StepServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/StepServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/TurnServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/agents/TurnServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.agents

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/chat/CompletionServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/chat/CompletionServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.chat

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/eval/JobServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/eval/JobServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.eval

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/postTraining/JobServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/postTraining/JobServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.postTraining

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/responses/InputItemServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/responses/InputItemServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.responses

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/toolRuntime/RagToolServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.toolRuntime

--- a/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileServiceTest.kt
+++ b/llama-stack-client-kotlin-core/src/test/kotlin/com/llama/llamastack/services/blocking/vectorStores/FileServiceTest.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.services.blocking.vectorStores

--- a/llama-stack-client-kotlin/build.gradle.kts
+++ b/llama-stack-client-kotlin/build.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 plugins {
     id("llama-stack-client.kotlin")
     id("llama-stack-client.publish")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 rootProject.name = "llama-stack-client-kotlin-root"
 
 include("llama-stack-client-kotlin")


### PR DESCRIPTION
… files

- Added License section to README.md referencing MIT License
- Added Meta Platforms copyright headers to 711 Kotlin and shell script files
- Ensures OSS compliance with Meta's requirements