### PR TITLE
Add copyright headers to example and okhttp client files

### DIFF
--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/AvailableFunctions.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/AvailableFunctions.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 class AvailableFunctions private constructor() {

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/CustomTools.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/CustomTools.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import com.llama.llamastack.models.ToolDef

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ExampleLlamaStackLocalInference.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ExampleLlamaStackLocalInference.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.content.Context

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ExampleLlamaStackRemoteInference.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ExampleLlamaStackRemoteInference.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.content.ContentResolver

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/FileUtils.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/FileUtils.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.content.Context

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/LocalRagUtils.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/LocalRagUtils.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import com.llama.llamastack.client.LlamaStackClientClient

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/RemoteRagUtils.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/RemoteRagUtils.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.content.Context

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/SentenceEmbeddingModel.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/SentenceEmbeddingModel.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.util.Log

--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ToolCalling.kt
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/ToolCalling.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.example.llamastackandroiddemo
 
 import android.Manifest

--- a/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/LlamaStackClientOkHttpClient.kt
+++ b/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/LlamaStackClientOkHttpClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client.okhttp

--- a/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/LlamaStackClientOkHttpClientAsync.kt
+++ b/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/LlamaStackClientOkHttpClientAsync.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 // File generated from our OpenAPI spec by Stainless.
 
 package com.llama.llamastack.client.okhttp

--- a/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/OkHttpClient.kt
+++ b/llama-stack-client-kotlin-client-okhttp/src/main/kotlin/com/llama/llamastack/client/okhttp/OkHttpClient.kt
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the terms described in the LICENSE file in
+// the root directory of this source tree.
+
 package com.llama.llamastack.client.okhttp
 
 import com.llama.llamastack.core.RequestOptions


### PR DESCRIPTION
- Added Meta Platforms copyright headers to 9 example Android app files
- Added Meta Platforms copyright headers to 3 okhttp client files